### PR TITLE
Fix exception in gaze tracking.

### DIFF
--- a/tracker.py
+++ b/tracker.py
@@ -50,7 +50,7 @@ def compensate(p1, p2):
 def rotate_image(image, a, center):
     (h, w) = image.shape[:2]
     a = np.rad2deg(a)
-    M = cv2.getRotationMatrix2D((int(center[0]), int(center[1])), a, 1.0)
+    M = cv2.getRotationMatrix2D((float(center[0]), float(center[1])), a, 1.0)
     rotated = cv2.warpAffine(image, M, (w, h))
     return rotated
 

--- a/tracker.py
+++ b/tracker.py
@@ -50,7 +50,7 @@ def compensate(p1, p2):
 def rotate_image(image, a, center):
     (h, w) = image.shape[:2]
     a = np.rad2deg(a)
-    M = cv2.getRotationMatrix2D((center[0], center[1]), a, 1.0)
+    M = cv2.getRotationMatrix2D((int(center[0]), int(center[1])), a, 1.0)
     rotated = cv2.warpAffine(image, M, (w, h))
     return rotated
 


### PR DESCRIPTION
### Environment
```
Linux pc00 4.19.0-9-amd64 #1 SMP Debian 4.19.118-2+deb10u1 (2020-06-07) x86_64 GNU/Linux
python 3.7
numpy 1.20.3
opencv-python 4.5.2.54
```

### Issue
When running on linux gaze is not tracked due to incorrect typing in `rotate_image()` function.
Exception is caught silently and ignored in `predict()`:
```python
            if conf > self.threshold:
                try:
                    eye_state = self.get_eye_state(frame, lms)
                except:
                    eye_state = [(1.0, 0.0, 0.0, 0.0), (1.0, 0.0, 0.0, 0.0)]
```
This results in gaze being fixed without user understanding why.
Exception after catching is:
```
Traceback (most recent call last):
  File "/home/rez/python/OpenSeeFace/facetracker.py", line 257, in <module>
    faces = tracker.predict(frame)
  File "/home/rez/python/OpenSeeFace/tracker.py", line 1116, in predict
    eye_state = self.get_eye_state(frame, lms)
  File "/home/rez/python/OpenSeeFace/tracker.py", line 936, in get_eye_state
    (right_eye, e_x[0], e_y[0], scale[0], reference[0], angles[0]) = self.prepare_eye(face_frame, frame, np.array([lms[36,0:2], lms[39,0:2]]), False)
  File "/home/rez/python/OpenSeeFace/tracker.py", line 891, in prepare_eye
    im = rotate_image(frame[:, :, ::], a, reference)
  File "/home/rez/python/OpenSeeFace/tracker.py", line 53, in rotate_image
    M = cv2.getRotationMatrix2D((center[0], center[1]), a, 1.0)
TypeError: Can't parse 'center'. Sequence item with index 0 has a wrong type
```

This simple fix casts both `center[0]` and `center[1]` to python `int` from `numpy.int64`, allowing gaze tracking to work properly.