### PR TITLE
specify list of providers for onnxruntime.InferenceSession()

### DIFF
--- a/retinaface.py
+++ b/retinaface.py
@@ -66,7 +66,8 @@ class RetinaFaceDetector():
         options.execution_mode = onnxruntime.ExecutionMode.ORT_SEQUENTIAL
         options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_ALL
         options.log_severity_level = 3
-        self.session = onnxruntime.InferenceSession(model_path, sess_options=options)
+        providersList = onnxruntime.capi._pybind_state.get_available_providers()
+        self.session = onnxruntime.InferenceSession(model_path, sess_options=options, providers=providersList)
         self.res_w, self.res_h = res
         with open(json_path, "r") as prior_file:
             self.priorbox = np.array(json.loads(prior_file.read()))

--- a/tracker.py
+++ b/tracker.py
@@ -527,8 +527,12 @@ class Tracker():
         self.retinaface_scan = RetinaFaceDetector(model_path=os.path.join(model_base_path, "retinaface_640x640_opt.onnx"), json_path=os.path.join(model_base_path, "priorbox_640x640.json"), threads=2, top_k=max_faces, res=(640, 640))
         self.use_retinaface = use_retinaface
 
+        # OTR 1.9 and later requires specifying providers
+        # explicitly as an argument in InferenceSession()
+        providersList = onnxruntime.capi._pybind_state.get_available_providers()
+
         # Single face instance with multiple threads
-        self.session = onnxruntime.InferenceSession(os.path.join(model_base_path, model), sess_options=options)
+        self.session = onnxruntime.InferenceSession(os.path.join(model_base_path, model), sess_options=options, providers=providersList)
 
         # Multiple faces with single threads
         self.sessions = []
@@ -544,7 +548,7 @@ class Tracker():
                 options.intra_op_num_threads += 1
             options.execution_mode = onnxruntime.ExecutionMode.ORT_SEQUENTIAL
             options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_ALL
-            self.sessions.append(onnxruntime.InferenceSession(os.path.join(model_base_path, model), sess_options=options))
+            self.sessions.append(onnxruntime.InferenceSession(os.path.join(model_base_path, model), sess_options=options, providers=providersList))
         self.input_name = self.session.get_inputs()[0].name
 
         options = onnxruntime.SessionOptions()
@@ -553,9 +557,9 @@ class Tracker():
         options.execution_mode = onnxruntime.ExecutionMode.ORT_SEQUENTIAL
         options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_ALL
         options.log_severity_level = 3
-        self.gaze_model = onnxruntime.InferenceSession(os.path.join(model_base_path, "mnv3_gaze32_split_opt.onnx"), sess_options=options)
+        self.gaze_model = onnxruntime.InferenceSession(os.path.join(model_base_path, "mnv3_gaze32_split_opt.onnx"), sess_options=options, providers=providersList)
 
-        self.detection = onnxruntime.InferenceSession(os.path.join(model_base_path, "mnv3_detection_opt.onnx"), sess_options=options)
+        self.detection = onnxruntime.InferenceSession(os.path.join(model_base_path, "mnv3_detection_opt.onnx"), sess_options=options, providers=providersList)
         self.faces = []
 
         # Image normalization constants


### PR DESCRIPTION
apparently, onnxruntime 1.9 and later require that the available providers be explicitly listed as an argument in InferenceSession()
or i was getting that error anyway, and it was preventing OpenSeeFace from working
i'm running Arch Linux using the build of python-onnxruntime available in the AUR
anyway, i edited tracker.py and retinaface.py to find the list of available providers and pass that argument
and that makes it work for me!
i've never really used github before so i hope i'm doing this right >w< thank you for the good software!