### PR TITLE
Changed requirments to fix AttributeError caused by numpy v1.24

### DIFF
--- a/make_exe.bat
+++ b/make_exe.bat
@@ -11,7 +11,7 @@ call venv\Scripts\activate.bat
 echo "Installing dependencies"
 pip install wheel
 
-pip install onnxruntime opencv-python==4.5.4.60 pillow numpy pyinstaller
+pip install onnxruntime opencv-python==4.5.4.60 pillow numpy==1.23.0 pyinstaller
 
 echo "Running pyinstaller"
 pyinstaller facetracker.py --clean ^

--- a/make_exe.sh
+++ b/make_exe.sh
@@ -21,7 +21,7 @@ source venv/bin/activate
 echo "Installing packages"
 pip install wheel # Make sure this is installed beforehand
 
-pip install onnxruntime opencv-python==4.5.4.60 pillow numpy pyinstaller
+pip install onnxruntime opencv-python==4.5.4.60 pillow numpy==1.23.0 pyinstaller
 
 echo "Creating binary"
 pyinstaller --onedir --clean facetracker.py \


### PR DESCRIPTION
When building with the latest numpy version (v1.24.0), OpenSeeFace crashes with "AttributeError: module 'numpy' has no attribute 'float'". This is because the attribute 'float' is now deprecated in numpy v1.24. I have changed the requirements to the earlier version v1.23.0. This should probably only be a temporary fix, as I'm sure there is a good reason that float was depreciated. I would also recommend changing the requirements to a single file with a static version for each requirement that is known to work. This will help ensure the stability of the program. I may do this in another fork when I have more time if you want.