### PR TITLE
Removed deprecated use of 'np.int' and replaced it with 'int'. Fixes numpy 1.24.0.

### DIFF
--- a/model.py
+++ b/model.py
@@ -251,7 +251,7 @@ def AdapWingLoss(pre_hm, gt_hm):
         img_dilate = cv2.morphologyEx(img_merge, cv2.MORPH_DILATE, kernel)
         img_dilate[img_dilate < 51] = 1  # 0*W+1
         img_dilate[img_dilate >= 51] = 11  # 1*W+1
-        img_dilate = np.array(img_dilate, dtype=np.int)
+        img_dilate = np.array(img_dilate, dtype=int)
         img_dilate = img_dilate.transpose(2, 0, 1)
         dilated = torch.from_numpy(img_dilate).float()
         if first:

--- a/tracker.py
+++ b/tracker.py
@@ -920,7 +920,7 @@ class Tracker():
         x1, y1 = clamp_to_im(center - radius, h, w)
         x2, y2 = clamp_to_im(center + radius + 1, h, w)
         offset = np.array((x1, y1))
-        lms = (lms[:, 0:2] - offset).astype(np.int)
+        lms = (lms[:, 0:2] - offset).astype(int)
         frame = frame[y1:y2, x1:x2]
         return frame, lms, offset
 


### PR DESCRIPTION
Hiya! I was working on getting OpenSeeFace working on my Steam Deck and ended up with a newer version of numpy (1.24.3) after following the Python 3.10 dependency installation instructions.

This version of numpy has fully deprecated the use of np.int, so it actually breaks instead of printing a warning. This was causing eye tracking to throw an exception that got silently handled.

This fixes issue #53 .