### PR TITLE
Don't destroy windows if visualization disabled

### DIFF
--- a/facetracker.py
+++ b/facetracker.py
@@ -447,7 +447,8 @@ except KeyboardInterrupt:
 input_reader.close()
 if out is not None:
     out.release()
-cv2.destroyAllWindows()
+if args.visualize != 0:
+    cv2.destroyAllWindows()
 
 if args.silent == 0 and tracking_frames > 0:
     average_tracking_time = 1000 * tracking_time / tracking_frames


### PR DESCRIPTION
This fixes the following error on exit when OpenCV is built without GUI support:

```
Traceback (most recent call last):
  File "facetracker.py", line 450, in <module>
cv2.error: OpenCV(4.9.0) /build/source/modules/highgui/src/window.cpp:1266: error: (-2:Unspecified error) The function is not implemented. Rebuild the library with Windows, GTK+ 2.x or Cocoa support. If you are on Ubuntu or Debian, install libgtk2.0-dev and pkg-config, then re-run cmake or configure script in function 'cvDestroyAllWindows'

[254225] Failed to execute script 'facetracker' due to unhandled exception!
```